### PR TITLE
Clean data

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 /target
+data

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -81,7 +81,7 @@ checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
 
 [[package]]
 name = "chem-matcher"
-version = "0.0.0"
+version = "0.0.1"
 dependencies = [
  "flate2",
  "flume",
@@ -89,7 +89,9 @@ dependencies = [
  "regex",
  "reqwest",
  "rust-stemmers",
+ "serde",
  "serde_json",
+ "stringzilla",
  "structopt",
  "tempdir",
  "tokio",
@@ -972,6 +974,9 @@ name = "serde"
 version = "1.0.164"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9e8c8cf938e98f769bc164923b06dce91cea1751522f46f8466461af04c9027d"
+dependencies = [
+ "serde_derive",
+]
 
 [[package]]
 name = "serde_derive"
@@ -1048,6 +1053,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6980e8d7511241f8acf4aebddbb1ff938df5eebe98691418c4468d0b72a96a67"
 dependencies = [
  "lock_api",
+]
+
+[[package]]
+name = "stringzilla"
+version = "3.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f96114fe0ec9e52c180b2b1a531066b90cebc7c56a5bb99aa23a11ae37f7334f"
+dependencies = [
+ "cc",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "chem-matcher"
-version = "0.0.0"
+version = "0.0.1"
 edition = "2021"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
@@ -13,6 +13,7 @@ rust-stemmers = "1.2.0"
 tokio = { version = "1", features = ["full"] }
 flume = "0.10.14"
 serde_json = "1.0.70"
+serde = { version = "1.0", features = ["derive"] }
 tempdir = "0.3"
 flate2 = "1.0.26"
 regex = "1.8.4"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,3 +17,4 @@ serde = { version = "1.0", features = ["derive"] }
 tempdir = "0.3"
 flate2 = "1.0.26"
 regex = "1.8.4"
+stringzilla = "3.3.1"

--- a/data/get_s2orc.py
+++ b/data/get_s2orc.py
@@ -1,10 +1,11 @@
 import requests
 import os
 from dotenv import load_dotenv
+from tqdm import tqdm
 
 load_dotenv()
 
-base_url = "https://api.semanticscholar.org/datasets/v1/release/"
+base_url = "https://api.semanticscholar.org/datasets/v1/release"
 response = requests.get(base_url)
 if response.status_code == 200:
    release_id = response.json()[-1]
@@ -23,14 +24,15 @@ else:
     raise Exception(f"Failed to get dataset info: Status code {response.status_code}")
 
 for i, url in enumerate(response_data['files'], start=1):
+    if i > 10: break # don't want to download all 260GB
     filename = url.split('/')[-1].split('?')[0]  
     response = requests.get(url, stream=True)  
 
     if response.status_code == 200:
+        print(f"Downloading chunk{i}: {filename}")
         with open(f"chunk{i}.gz", 'wb') as file:
-            for chunk in response.iter_content(chunk_size=128):
+            for chunk in tqdm(response.iter_content(chunk_size=128)):
                 file.write(chunk)
         print(f"Downloaded chunk{i}: {filename}")
     else:
         print(f"Failed to download {filename}: Status code {response.status_code}")
-

--- a/data/get_s2orc.py
+++ b/data/get_s2orc.py
@@ -24,10 +24,10 @@ else:
     raise Exception(f"Failed to get dataset info: Status code {response.status_code}")
 
 for i, url in enumerate(response_data['files'], start=1):
-    if i > 10: break # don't want to download all 260GB
+    if i > 1: break # don't want to download all 260GB
     filename = url.split('/')[-1].split('?')[0]  
     response = requests.get(url, stream=True)  
-
+    print(filename)
     if response.status_code == 200:
         print(f"Downloading chunk{i}: {filename}")
         with open(f"chunk{i}.gz", 'wb') as file:

--- a/data/get_s2orc.py
+++ b/data/get_s2orc.py
@@ -1,0 +1,36 @@
+import requests
+import os
+from dotenv import load_dotenv
+
+load_dotenv()
+
+base_url = "https://api.semanticscholar.org/datasets/v1/release/"
+response = requests.get(base_url)
+if response.status_code == 200:
+   release_id = response.json()[-1]
+else:
+    raise Exception(f"Failed to get latest release ID: Status code {response.status_code}")
+
+headers = {"x-api-key": os.environ.get("SEMANTIC_SCHOLAR_API_KEY")}
+base_url = f"{base_url}/{release_id}"
+response = requests.get(f"{base_url}/dataset/s2orc", headers=headers)
+
+if response.status_code == 200:
+   response_data = response.json()
+   print(response_data.keys())
+   print(len(response_data['files']))
+else:
+    raise Exception(f"Failed to get dataset info: Status code {response.status_code}")
+
+for i, url in enumerate(response_data['files'], start=1):
+    filename = url.split('/')[-1].split('?')[0]  
+    response = requests.get(url, stream=True)  
+
+    if response.status_code == 200:
+        with open(f"chunk{i}.gz", 'wb') as file:
+            for chunk in response.iter_content(chunk_size=128):
+                file.write(chunk)
+        print(f"Downloaded chunk{i}: {filename}")
+    else:
+        print(f"Failed to download {filename}: Status code {response.status_code}")
+

--- a/data/run.sh
+++ b/data/run.sh
@@ -5,13 +5,13 @@ cargo build --release
 cp ../target/release/chem-matcher .
 
 
-# FILE_PATHS=$(find . -name "chunk*.gz" | sort | sed 's|\./||g')
-# ./chem-matcher  -c ../../../Data/CID-Synonym-filtered \
-#                 -f $FILE_PATHS \
-#                 -o output.csv
-
-# ./chem-matcher  -c ../../../Data/test_map2 \
-# ./chem-matcher  -c ../../../Data/CID-SMILES-Synonyms \
+FILE_PATHS=$(find . -name "chunk*.gz" | sort | sed 's|\./||g')
 ./chem-matcher  -c ../../../Data/CID-Synonym-filtered \
-                -f chunk1.gz \
+                -f $FILE_PATHS \
                 -o output.csv --stop 2000
+
+# ./chem-matcher  -c ../../../Data/test_map \
+# ./chem-matcher  -c ../../../Data/CID-SMILES-Synonyms \
+#                 -f chunk1.gz \
+#                 -o output.csv --stop 2000
+# ./chem-matcher  -c ../../../Data/CID-Synonym-filtered \

--- a/data/run.sh
+++ b/data/run.sh
@@ -6,12 +6,10 @@ cp ../target/release/chem-matcher .
 
 
 FILE_PATHS=$(find . -name "chunk*.gz" | sort | sed 's|\./||g')
-./chem-matcher  -c ../../../Data/CID-Synonym-filtered \
-                -f $FILE_PATHS \
-                -o output.csv --stop 2000
-
-# ./chem-matcher  -c ../../../Data/test_map \
-# ./chem-matcher  -c ../../../Data/CID-SMILES-Synonyms \
-#                 -f chunk1.gz \
-#                 -o output.csv --stop 2000
 # ./chem-matcher  -c ../../../Data/CID-Synonym-filtered \
+#                 -f $FILE_PATHS \
+#                 -o s2orc.csv
+
+./chem-matcher  -c ../../../Data/CID-SMILES-Synonyms \
+                -f $FILE_PATHS \
+                -o s2orc.csv

--- a/data/run.sh
+++ b/data/run.sh
@@ -1,0 +1,17 @@
+#!/bin/bash
+set -e
+
+cargo build --release
+cp ../target/release/chem-matcher .
+
+
+# FILE_PATHS=$(find . -name "chunk*.gz" | sort | sed 's|\./||g')
+# ./chem-matcher  -c ../../../Data/CID-Synonym-filtered \
+#                 -f $FILE_PATHS \
+#                 -o output.csv
+
+# ./chem-matcher  -c ../../../Data/test_map2 \
+# ./chem-matcher  -c ../../../Data/CID-SMILES-Synonyms \
+./chem-matcher  -c ../../../Data/CID-Synonym-filtered \
+                -f chunk1.gz \
+                -o output.csv --stop 2000

--- a/src/main.rs
+++ b/src/main.rs
@@ -262,7 +262,7 @@ fn search_keys_in_text<'a>(map: &'a HashMap<String, String>, text: &'a str) -> S
 //             if seen {
 //                 continue; //Ignores all other keys if one key was found before
 //             }
-
+//
 //             if paragraph.to_lowercase().sz_find(key.to_lowercase()).is_none() {
 //                 continue;
 //             }
@@ -336,9 +336,9 @@ async fn process_files(opt: Opt) -> Result<(), Box<dyn Error>> {
                         if opt.stop > 0 && count == opt.stop {
                             break;
                         }
-                        if count % 100 == 0 {
-                            println!("Processing file {}", count);
-                        }
+                        // if count % 1000 == 0 {
+                        //     println!("Processing file {}", count);
+                        // }
                         // skip empty lines
                         if line.as_ref().unwrap().is_empty() {
                             continue;

--- a/src/main.rs
+++ b/src/main.rs
@@ -26,8 +26,8 @@ use stringzilla::StringZilla;
 
 const WORD_SPLITS: &[char] = &[' ', '\t', '\n', '\r', ',', '.', ';', ':', '!', '?', '(', ')', '[', ']', '{', '}', '<', '>', '"', '\''];
 const MIN_WORD_LENGTH: usize = 5;
-// const BANNED: &str = "https://raw.githubusercontent.com/first20hours/google-10000-english/master/20k.txt";
-const BANNED: &str = "https://raw.githubusercontent.com/dwyl/english-words/master/words.txt";
+const BANNED: &str = "https://raw.githubusercontent.com/first20hours/google-10000-english/master/20k.txt";
+// const BANNED: &str = "https://raw.githubusercontent.com/dwyl/english-words/master/words.txt";
 const MASK: &str = "<|MOLECULE|>";
 
 type SearchResults = Vec<(String, String, String)>;

--- a/src/main.rs
+++ b/src/main.rs
@@ -194,7 +194,6 @@ fn generate_report(search_results: SearchResults, writer: &mut BufWriter<File>, 
 }
 
 async fn process_files(opt: Opt) -> Result<(), Box<dyn Error>> {
-    println!("opt: {:?}", opt);
     let banned = Arc::new(fetch_words_from_url(BANNED).await.unwrap());
     let map = Arc::new(parse_csv(&opt.csv_file, &banned)?);
     let (tx, rx) = flume::unbounded();

--- a/src/main.rs
+++ b/src/main.rs
@@ -13,6 +13,7 @@ use flume;
 use flate2::read::GzDecoder;
 use flate2::write::GzEncoder;
 use flate2::Compression;
+use serde_json::Value;
 use serde::{Deserialize, Serialize};
 // use serde_json::Result;
 use std::io::prelude::*;

--- a/src/main.rs
+++ b/src/main.rs
@@ -14,7 +14,9 @@ use flate2::read::GzDecoder;
 use flate2::write::GzEncoder;
 use flate2::Compression;
 use serde_json::Value;
-use serde::{Deserialize, Serialize};
+use serde::{Deserialize, Deserializer, Serialize, Serializer};
+use serde::de::{self, Visitor};
+use std::fmt;
 // use serde_json::Result;
 use std::io::prelude::*;
 use regex;
@@ -24,10 +26,11 @@ use stringzilla::StringZilla;
 
 const WORD_SPLITS: &[char] = &[' ', '\t', '\n', '\r', ',', '.', ';', ':', '!', '?', '(', ')', '[', ']', '{', '}', '<', '>', '"', '\''];
 const MIN_WORD_LENGTH: usize = 5;
-const BANNED: &str = "https://raw.githubusercontent.com/first20hours/google-10000-english/master/20k.txt";
+// const BANNED: &str = "https://raw.githubusercontent.com/first20hours/google-10000-english/master/20k.txt";
+const BANNED: &str = "https://raw.githubusercontent.com/dwyl/english-words/master/words.txt";
 const MASK: &str = "<|MOLECULE|>";
 
-type SearchResults = Vec<(String, String, String)>;
+type SearchResults = Vec<(String, String, u32)>;
 
 #[derive(StructOpt, Debug)]
 #[structopt(name = "key-search")]
@@ -54,9 +57,45 @@ struct Opt {
 
 }
 
+// Custom deserialization function
+fn deserialize_usize_or_string<'de, D>(deserializer: D) -> Result<usize, D::Error>
+where
+    D: Deserializer<'de>,
+{
+    struct UsizeOrString;
+
+    impl<'de> Visitor<'de> for UsizeOrString {
+        type Value = usize;
+
+        fn expecting(&self, formatter: &mut fmt::Formatter) -> fmt::Result {
+            formatter.write_str("an integer or a string that can be parsed as an integer")
+        }
+
+        // For directly encountering an integer
+        fn visit_u64<E>(self, value: u64) -> Result<usize, E>
+        where
+            E: de::Error,
+        {
+            Ok(value as usize)
+        }
+
+        // For encountering a string that needs to be parsed
+        fn visit_str<E>(self, value: &str) -> Result<usize, E>
+        where
+            E: de::Error,
+        {
+            value.parse::<usize>().map_err(de::Error::custom)
+        }
+    }
+
+    deserializer.deserialize_any(UsizeOrString)
+}
+
 #[derive(Serialize, Deserialize, Debug)]
 struct Paragraph {
+    #[serde(deserialize_with = "deserialize_usize_or_string")]
     start: usize,
+    #[serde(deserialize_with = "deserialize_usize_or_string")]
     end: usize,
 }
 
@@ -102,7 +141,7 @@ fn from_ascii_titlecase(s: &str) -> String {
 
 async fn fetch_words_from_url(url: &str) -> Result<HashSet<String>, Box<dyn Error>> {
     let response = reqwest::get(url).await?;
-    let pb = ProgressBar::new(20000 as u64);
+    let pb = ProgressBar::new(466000 as u64);
     pb.set_style(
         ProgressStyle::default_bar()
             .template("fetching common words [{elapsed_precise}] {bar} {pos}/{len} ({eta})")?
@@ -124,7 +163,7 @@ async fn fetch_words_from_url(url: &str) -> Result<HashSet<String>, Box<dyn Erro
 }
 
 // Read CSV file and returns a HashMap with key-value pairs
-fn parse_csv(file_path: &str, banned: &HashSet<String>) -> Result<HashMap<String, String>, Box<dyn Error>> {
+fn parse_csv(file_path: &str, banned: &HashSet<String>) -> Result<HashMap<String, u32>, Box<dyn Error>> {
     let estimate = estimate_lines(file_path)?;
     let mut map = HashMap::with_capacity(estimate);
     let stemmer = StemmerWrapper::new();
@@ -141,11 +180,11 @@ fn parse_csv(file_path: &str, banned: &HashSet<String>) -> Result<HashMap<String
 
     for line in content.lines() {
         let split: Vec<&str> = line.split('\t').collect();
-        if split.len() == 3 { // CID SMILES NAME
-            let value = split[1].trim().to_string();
-            let key = split[2].trim().to_string();
+        if split.len() == 2 { // CID SMILES NAME
+            let value = split[0].trim().to_string();
+            let key = split[1].trim().to_string();
             if key.len() >= MIN_WORD_LENGTH && !banned.contains(stemmer.standardize(&key).as_str()) {
-                map.insert(to_ascii_titlecase(&key), value); //.parse::<u32>().unwrap());
+                map.insert(to_ascii_titlecase(&key), value.parse::<u32>().unwrap());
             } else {
                 skipped += 1;
             }
@@ -159,48 +198,101 @@ fn parse_csv(file_path: &str, banned: &HashSet<String>) -> Result<HashMap<String
     Ok(map)
 }
 
-
-fn search_keys_in_text<'a>(map: &'a HashMap<String, String>, text: &'a str) -> SearchResults {
-    let mut search_results: SearchResults = Vec::new();
+fn search_keys_in_text<'a>(map: &'a HashMap<String, u32>, text: &'a str) -> SearchResults {
+    let mut search_results = Vec::new();
     let re = regex::Regex::new(r"\n\n").unwrap();
     re.split(text).map(|paragraph| {
-        let mut seen:bool = false; // we only want to observer a key once
-        for (key, value) in map {
-            // if seen {
-            //     continue; //Ignores all other keys if one key was found before
-            // }
+        let mut count: usize = 0;
+        let mut last_word = String::new();
+        let mut last_count: usize = 0;
+        let mut last_key = String::new();
+        let mut seen = HashSet::new(); // we only want to observer a key once
+        paragraph.split(WORD_SPLITS).map(|word| {
+            count += word.len() + 1;
+            let title_word = to_ascii_titlecase(word);
+            let mut value: Option<&u32> = None;
+            last_key.clear();
+            last_key.push_str(&last_word);
+            last_key.push(' ');
+            last_key.push_str(word);
+            if word.len() >= MIN_WORD_LENGTH && map.contains_key(&last_key) && !seen.contains(&last_key) {
+                value = map.get(&last_key);
+            } else if last_word.len() >= MIN_WORD_LENGTH && map.contains_key(&last_word) && !seen.contains(&last_word) {
+                value = map.get(&last_word);
+                last_key.clear();
+                last_key.push_str(&last_word);
+            }
+            
+            if value.is_some() {
+                // need to copy paragraph so I can mask out the word
+                let mut paragraph = paragraph.to_string().replace(&last_key, MASK);
+                paragraph = paragraph.replace(from_ascii_titlecase(&last_key).as_str(), MASK);
+                seen.insert(last_key.to_string());
+                search_results.push((paragraph, last_key.to_string(), *value.unwrap()));
+            }
+    
+            last_word = title_word.to_string();
+            last_count = count;
+        }).count();
 
-            if paragraph.to_lowercase().sz_find(key.to_lowercase()).is_none() {
-                continue;
+        // add the last word
+        if last_word.len() >= MIN_WORD_LENGTH && map.contains_key(&last_word) && !seen.contains(&last_word) {
+            let value = map.get(&last_word);
+            if value.is_some() {
+                // need to copy paragraph so I can mask out the word
+                let mut paragraph = paragraph.to_string().replace(&last_word, MASK);
+                paragraph = paragraph.replace(from_ascii_titlecase(&last_word).as_str(), MASK);
+                seen.insert(last_word.to_string());
+                search_results.push((paragraph.replace(&last_word, MASK), last_word.to_string(), *value.unwrap()));
             }
-            else {
-                println!("Found key: {}", key);
-                // let mut paragraph = paragraph.to_string().replace(key, MASK);
-                // paragraph = paragraph.replace(from_ascii_titlecase(key).as_str(), MASK);
-                // search_results.push((paragraph, key.to_string(), value.to_string()));
-                // seen = true;
-            }
-            // match paragraph.to_lowercase().contains(&key.to_lowercase()) {
-            //     true => {
-            //         // println!("Match found");
-            //         // println!("Key: {}. Value: {}", key, value);
-            //         let mut paragraph = paragraph.to_string().replace(key, MASK);
-            //         paragraph = paragraph.replace(from_ascii_titlecase(key).as_str(), MASK);
-            //         search_results.push((paragraph, key.to_string(), value.to_string()));
-            //         seen = true;
-            //     },
-            //     false => {
-            //         // println!("No match found.");
-            //         // println!("Key: {}. Value: {}", key, value);
-            //         // println!("Paragraph: {}", paragraph);
-            //     },
-            // }
         }
+
     }).count();
 
     search_results
 }
 
+// Slow performance search_keys_in_text algorithm. It doesn't use WORD_SPLIt, so I might want to optimize this later
+// fn search_keys_in_text<'a>(map: &'a HashMap<String, u32>, text: &'a str) -> SearchResults {
+//     let mut search_results: SearchResults = Vec::new();
+//     let re = regex::Regex::new(r"\n\n").unwrap();
+//     re.split(text).map(|paragraph| {
+//         let mut seen:bool = false; // we only want to observer a key once
+//         for (key, value) in map {
+//             if seen {
+//                 continue; //Ignores all other keys if one key was found before
+//             }
+
+//             if paragraph.to_lowercase().sz_find(key.to_lowercase()).is_none() {
+//                 continue;
+//             }
+//             else {
+//                 // println!("Found key: {}", key);
+//                 let mut paragraph = paragraph.to_string().replace(key, MASK);
+//                 paragraph = paragraph.replace(from_ascii_titlecase(key).as_str(), MASK);
+//                 search_results.push((paragraph, key.to_string(), value.to_string()));
+//                 seen = true;
+//             }
+//             // match paragraph.to_lowercase().contains(&key.to_lowercase()) {
+//             //     true => {
+//             //         // println!("Match found");
+//             //         // println!("Key: {}. Value: {}", key, value);
+//             //         let mut paragraph = paragraph.to_string().replace(key, MASK);
+//             //         paragraph = paragraph.replace(from_ascii_titlecase(key).as_str(), MASK);
+//             //         search_results.push((paragraph, key.to_string(), value.to_string()));
+//             //         seen = true;
+//             //     },
+//             //     false => {
+//             //         // println!("No match found.");
+//             //         // println!("Key: {}. Value: {}", key, value);
+//             //         // println!("Paragraph: {}", paragraph);
+//             //     },
+//             // }
+//         }
+//     }).count();
+
+//     search_results
+// }
 
 // Generate the report in a readable format
 fn generate_report(search_results: SearchResults, writer: &mut BufWriter<File>, paper_id: &str) {
@@ -219,7 +311,7 @@ async fn process_files(opt: Opt) -> Result<(), Box<dyn Error>> {
     for (index, file_path) in opt.files.iter().enumerate() {
         let property = opt.property.clone();
         let fp = file_path.to_str().unwrap().to_string();
-        let map: Arc<HashMap<String, String>> = Arc::clone(&map);
+        let map: Arc<HashMap<String, u32>> = Arc::clone(&map);
         let tx = tx.clone();
         let output_file = opt.output_file.clone();
         tokio::spawn(async move {
@@ -244,7 +336,7 @@ async fn process_files(opt: Opt) -> Result<(), Box<dyn Error>> {
                         if opt.stop > 0 && count == opt.stop {
                             break;
                         }
-                        if count % 1000 == 0 {
+                        if count % 100 == 0 {
                             println!("Processing file {}", count);
                         }
                         // skip empty lines
@@ -267,12 +359,12 @@ async fn process_files(opt: Opt) -> Result<(), Box<dyn Error>> {
                                                     Err(e) => {
                                                         // TODO: Sometimes, the indexes are saved as strings. How to handle this?
                                                         println!("Error: {}", e);
-                                                        continue;
+                                                        break;
                                                     }
                                                 }
                                             },
                                             None => {
-                                                println!("Error: No paragraphs found");
+                                                // println!("Error: No paragraphs annotation found");
                                                 continue;
                                             }
                                         }


### PR DESCRIPTION
This PR aims to implement two new features in the s2orc data curation:
- Use semantic scholar annotations to remove the title, author names and affiliations, and references from the texts before scraping paragraphs; and
- Output a list containing [SMILES, IUPAC names, Descriptions and PID]. Substituting the CID previously output with the SMILES.